### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/src/Hop.Framework.Core.Tests/Hop.Framework.Core.Tests.csproj
+++ b/src/Hop.Framework.Core.Tests/Hop.Framework.Core.Tests.csproj
@@ -6,14 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="10.1.0" />
+    <PackageReference Include="FluentValidation" Version="10.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.1" />
     <PackageReference Include="NSubstitute" Version="4.0.0" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
-    <PackageReference Include="coverlet.msbuild" Version="2.5.1">
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Hi@DiegoTondim, I found an issue in the Hop.Framework.Core.Tests.csproj:

Packages FluentValidation v10.1.0, MSTest.TestAdapter v1.4.0, MSTest.TestFramework v1.4.0, NUnit v3.11.0, NUnit3TestAdapter v3.12.0 and coverlet.msbuild v2.5.1 transitively introduce 69 dependencies into hop-framework’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/hop-framework.html)), while FluentValidation v10.3.0, MSTest.TestAdapter v2.2.1, MSTest.TestFramework v2.2.1, NUnit v3.12.0, NUnit3TestAdapter v4.0.0 and coverlet.msbuild v2.9.0 can only introduce 41 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/hop-framework_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose